### PR TITLE
Add automatic language detection & translation for non-English titles

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ joblib>=1.0
 flask>=2.0
 flask-cors>=3.0
 requests>=2.25
+langdetect
+deep-translator

--- a/test/test_predict.py
+++ b/test/test_predict.py
@@ -10,7 +10,7 @@ parent_dir = os.path.dirname(current_dir)
 sys.path.insert(0, parent_dir)
 
 from backend.api.utils import predict_clickbait
-
+from backend.api.main import translate_to_english  
 
 # Model loading test
 try:
@@ -19,8 +19,8 @@ try:
     print("[SUCCESS] Model loaded successfully")
 except FileNotFoundError:
     print(f"[ERROR] Model file not found: {MODEL_PATH}")
+    sys.exit(1)
 
-# Test the predict_clickbait function
 try:
     test_titles = [
         "Google Cloud Associate Cloud Engineer Course - Pass the Exam!",
@@ -28,18 +28,32 @@ try:
         "You Won't Believe What Happened Next!"
     ]
 
-    # print("Clickbait Prediction Tests:\n")
-
+    print("\n[TEST] English Clickbait Predictions:\n")
     for title in test_titles:
         result = predict_clickbait(title, model_components)
-        # print(f"Title: {title}")
-        # print(f" → NB Probability:       {result['nb_probability']:.3f}")
-        # print(f" → RF Probability:       {result['rf_probability']:.3f}")
-        # print(f" → Combined Probability: {result['combined_probability']:.3f}")
-        # print(f" → Prediction:           {result['prediction']}\n")
+        print(f"Title: {title}")
+        print(f" → Prediction: {result['prediction']} | Combined Probability: {result['combined_probability']:.3f}")
 
-    # print("-" * 50)
-    print("[SUCCESS] Clickbait prediction tests completed successfully")    
+    print("[SUCCESS] English prediction tests passed\n")
 except Exception as e:
-    print(f"[ERROR] Error during clickbait prediction tests: {e}")
+    print(f"[ERROR] Error during English clickbait prediction tests: {e}")
 
+# testing non english title transltion + prediction
+try:
+    non_english_titles = [
+        "Este es un título increíble",      # spanish
+        "Ceci est un titre incroyable",     # french
+        "यह एक अविश्वसनीय शीर्षक है"       # hindi
+    ]
+
+    print("[TEST] Non-English Translation & Prediction:\n")
+    for title in non_english_titles:
+        translated = translate_to_english(title)
+        print(f"Original: {title}")
+        print(f"Translated: {translated}")
+        result = predict_clickbait(translated, model_components)
+        print(f" → Prediction: {result['prediction']} | Combined Probability: {result['combined_probability']:.3f}\n")
+
+    print("[SUCCESS] Non-English translation + prediction tests passed\n")
+except Exception as e:
+    print(f"[ERROR] Error during non-English prediction tests: {e}")


### PR DESCRIPTION
This PR adds multi-language support to the Clickbait Detector API by:
-> Automatically detecting the input title’s language.
-> Translating non-English titles into English before prediction.

**Changes:**
_1. backend/api/main.py_
- Added translate_to_english() helper using:
    -> [langdetect](https://pypi.org/project/langdetect/) — offline language detection.
    ->[deep-translator](https://pypi.org/project/deep-translator/) — free Google Translate API wrapper.
- Integrated translation step into /predict route before passing the title to predict_clickbait().

_2. requirements.txt_
- Added, langdetect and deep-translator

_3. added a few tests in predict_text.py_


_Working:_
>>> Invoke-WebRequest -Uri "http://localhost:8000/predict" `
>>   -Method POST `
>>   -ContentType "application/json" `
>>   -Body '{"title": "Ceci est un titre incroyable"}'


StatusCode        : 200
StatusDescription : OK
Content           : {
                      "combined_probability": 0.461543262262004,
                      "nb_probability": 0.923086524524008,
                      "prediction": 0,
                      "rf_probability": 0.0
                    }

RawContent        : HTTP/1.1 200 OK
                    Access-Control-Allow-Origin: *
                    Connection: close
                    Content-Length: 131
                    Content-Type: application/json
                    Date: Tue, 12 Aug 2025 07:00:23 GMT
                    Server: Werkzeug/3.1.3 Python/3.13.1

                    {
                    ...
Forms             : {}
Headers           : {[Access-Control-Allow-Origin, *], [Connection, close], [Content-Length, 131],
                    [Content-Type, application/json]...}
Images            : {}
InputFields       : {}
Links             : {}
ParsedHtml        : mshtml.HTMLDocumentClass
RawContentLength  : 131


 